### PR TITLE
fix: preserve newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,12 +56,13 @@ const splitLine = (text) => {
     textArray.pop()
   }
 
+  // Empty array are actually line segments so we convert them back to newlines
   return textArray.map((line) => {
     return {
       type: 'element',
       tagName: 'div',
       properties: { className: ['code-line'] },
-      children: [{ type: 'text', value: line }],
+      children: [{ type: 'text', value: line === '' ? '\n' : line }],
     }
   })
 }
@@ -122,7 +123,7 @@ const rehypePrism = (options) => {
       }
 
       // Syntax highlight
-      if (lang) {
+      if (lang && line.children) {
         try {
           line.children = refractor.highlight(line.children[0].value, lang).children
         } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-prism-plus",
-  "version": "0.0.1-beta.14",
+  "version": "0.0.2-canary0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-prism-plus",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "rehype plugin to highlight code blocks in HTML with Prism (via refractor) with line highlighting and line numbers",
   "source": "index.js",
   "files": [
@@ -8,7 +8,6 @@
   ],
   "main": "./dist/rehype-prism-plus.umd.js",
   "module": "./dist/rehype-prism-plus.es.js",
-  "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/test.js
+++ b/test.js
@@ -60,6 +60,23 @@ test('finds code and highlights', () => {
   assert.is(result, expected)
 })
 
+test('respects line spacing', () => {
+  const result = processHtml(dedent`
+<div>
+  <pre><code class="language-py">x
+
+y
+</code></pre>
+</div>
+`).trim()
+  const expected = dedent`
+    <div>
+    <pre class="language-py"><code class="language-py"><div class="code-line">x</div><div class="code-line">\n</div><div class="code-line">y</div></code></pre>
+    </div>
+    `
+  assert.is(result, expected)
+})
+
 test('handles uppercase correctly', () => {
   const result = processHtml(dedent`
     <div>


### PR DESCRIPTION
Preserve newline between code blocks.

Fix https://github.com/timlrx/tailwind-nextjs-starter-blog/issues/139