### PR TITLE
feat: custom starting index for line numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const calculateLinesToHighlight = (meta) => {
 }
 
 /**
- * Check if we want to start the line numbering from a given number or 0
+ * Check if we want to start the line numbering from a given number or 1
  * showLineNumbers=5, will start the numbering from 5
  * @param {string} meta
  * @returns {number}
@@ -72,7 +72,7 @@ const calculateStartingLine = (meta) => {
     } = RE.exec(meta)
     return Number(lines)
   }
-  return 0
+  return 1
 }
 
 /**
@@ -218,7 +218,7 @@ const rehypePrism = (options = {}) => {
     for (const [i, line] of codeLineArray.entries()) {
       // Code lines
       if (meta.toLowerCase().includes('showLineNumbers'.toLowerCase()) || options.showLineNumbers) {
-        line.properties.line = [(i + (startingLineNumber || 1)).toString()]
+        line.properties.line = [(i + startingLineNumber).toString()]
         line.properties.className.push('line-number')
       }
 

--- a/index.js
+++ b/index.js
@@ -58,6 +58,24 @@ const calculateLinesToHighlight = (meta) => {
 }
 
 /**
+ * Check if we want to start the line numbering from a given number or 0
+ * showLineNumbers=5, will start the numbering from 5
+ * @param {string} meta
+ * @returns {number}
+ */
+const calculateStartingLine = (meta) => {
+  const RE = /showLineNumbers=(?<lines>\d+)/i
+  // pick the line number after = using a named capturing group
+  if (RE.test(meta)) {
+    const {
+      groups: { lines },
+    } = RE.exec(meta)
+    return Number(lines)
+  }
+  return 0
+}
+
+/**
  * Split line to div node with className `code-line`
  *
  * @param {string} text
@@ -193,13 +211,14 @@ const rehypePrism = (options = {}) => {
     refractorRoot.children = splitTextByLine(refractorRoot.children)
 
     const shouldHighlightLine = calculateLinesToHighlight(meta)
+    const startingLineNumber = calculateStartingLine(meta)
     // @ts-ignore
     const codeLineArray = splitLine(toString(node))
 
     for (const [i, line] of codeLineArray.entries()) {
       // Code lines
       if (meta.toLowerCase().includes('showLineNumbers'.toLowerCase()) || options.showLineNumbers) {
-        line.properties.line = [(i + 1).toString()]
+        line.properties.line = [(i + (startingLineNumber || 1)).toString()]
         line.properties.className.push('line-number')
       }
 

--- a/test.js
+++ b/test.js
@@ -230,6 +230,26 @@ test('showLineNumbers property works in meta field', async () => {
   assert.not(result.match(/line="3"/g))
 })
 
+test('showLineNumbers property with custom index works in meta field', async () => {
+  const meta = 'showLineNumbers=5'
+  const result = processHtml(
+    dedent`
+    <div>
+      <pre>
+      <code class="language-py code-highlight">x = 6
+      y = 7
+      </code>
+      </pre>
+    </div>
+    `,
+    {},
+    meta
+  ).trim()
+  assert.ok(result.match(/line="5"/g))
+  assert.ok(result.match(/line="6"/g))
+  assert.not(result.match(/line="7"/g))
+})
+
 test('should support both highlighting and add line number', async () => {
   const meta = '{1} showLineNumbers'
   const result = processHtml(


### PR DESCRIPTION
this change allows to start numbering at any index 

## Usage:

`showLineNumbers=65` (here, numbering will start at index 65):

````javascript showLineNumbers=65
```javascript  showLineNumbers=65
const calculateStartingLine = (meta) => {
  const RE = /showLineNumbers=(?<lines>\d+)/i
  // pick the line number after = using a named capturing group
  if (RE.test(meta)) {
    const {
      groups: { lines },
    } = RE.exec(meta)
    return Number(lines)
  }
  return 1
}
```
````

will produce:

```html
<code class="language-javascript">
<span class="code-line line-number" line="65"><span class="token template-string"><span class="token template-punctuation string">`</span><span class="token template-punctuation string">`</span></span><span class="token template-string"><span class="token template-punctuation string">`</span><span class="token string">javascript title="rehype.js" showLineNumbers=65
</span></span></span><span class="code-line line-number" line="66"><span class="token template-string"><span class="token string">const calculateStartingLine = (meta) =&gt; {
</span></span></span><span class="code-line line-number" line="67"><span class="token template-string"><span class="token string">  const RE = /showLineNumbers=(?&lt;lines&gt;\d+)/i
</span></span></span><span class="code-line line-number" line="68"><span class="token template-string"><span class="token string">  // pick the line number after = using a named capturing group
</span></span></span><span class="code-line line-number" line="69"><span class="token template-string"><span class="token string">  if (RE.test(meta)) {
</span></span></span><span class="code-line line-number" line="70"><span class="token template-string"><span class="token string">    const {
</span></span></span><span class="code-line line-number" line="71"><span class="token template-string"><span class="token string">      groups: { lines },
</span></span></span><span class="code-line line-number" line="72"><span class="token template-string"><span class="token string">    } = RE.exec(meta)
</span></span></span><span class="code-line line-number" line="73"><span class="token template-string"><span class="token string">    return Number(lines)
</span></span></span><span class="code-line line-number" line="74"><span class="token template-string"><span class="token string">  }
</span></span></span><span class="code-line line-number" line="75"><span class="token template-string"><span class="token string">  return 0
</span></span></span><span class="code-line line-number" line="76"><span class="token template-string"><span class="token string">}
</span></span></span><span class="code-line line-number" line="77"><span class="token template-string"><span class="token string"></span><span class="token template-punctuation string">`</span></span><span class="token template-string"><span class="token template-punctuation string">`</span><span class="token template-punctuation string">`</span></span>
</span></code>
```

which looks like:

<img width="673" alt="image" src="https://user-images.githubusercontent.com/5432911/141687536-7d70d45c-7007-44a7-a5d4-33e014a0224b.png">

To start numbering from 1, simply use `showLineNumbers` or `showLineNumbers=true` without specifying the starting index

This is inspired from gatsby-remark-prismjs