### PR TITLE
remove console.dir

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -211,10 +211,8 @@ const rehypePrismGenerator = (refractor) => {
         refractorRoot = node.children
       }
 
-      console.dir(refractorRoot, { depth: null })
       // @ts-ignore
       refractorRoot = getNodePosition(refractorRoot)
-      console.dir(refractorRoot, { depth: null })
       refractorRoot.children = splitTextByLine(refractorRoot.children)
 
       const shouldHighlightLine = calculateLinesToHighlight(meta)


### PR DESCRIPTION
Everytimes the Remix app rebuild, it throw a bunch of logs on the terminal. Could we remove these `console.dir()`?

![Screen Shot 2022-01-09 at 00 25 21](https://user-images.githubusercontent.com/38455472/148653625-1104ebdf-8f63-4fba-9f78-f6fba6720e0c.png)
