### PR TITLE
upgrade refractor to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "hast-util-to-string": "^2.0.0",
     "parse-numeric-range": "^1.3.0",
-    "refractor": "^4.4.0",
+    "refractor": "^4.5.0",
     "rehype-parse": "^8.0.2",
     "unist-util-filter": "^4.0.0",
     "unist-util-visit": "^4.0.0"


### PR DESCRIPTION
Hi @timlrx👋,

This PR fixes a high security alert for `prismjs` which one of the `refractor`'s dependencies. `prismjs` released `1.27.0` to fix its vulnerability on XSS attacks.

You can find [more detail here](https://github.com/DawChihLiou/dawchihliou.github.io/security/dependabot/15).