### PR TITLE
fix: disable showLineNumbers on a per block basis

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -263,12 +263,17 @@ const rehypePrismGenerator = (refractor) => {
       const shouldHighlightLine = calculateLinesToHighlight(meta)
       const startingLineNumber = calculateStartingLine(meta)
       const codeLineArray = splitLine(toString(node))
-
+      const falseShowLineNumbersStr = [
+        'showlinenumbers=false',
+        'showlinenumbers="false"',
+        'showlinenumbers={false}',
+      ]
       for (const [i, line] of codeLineArray.entries()) {
         // Code lines
         if (
-          meta.toLowerCase().includes('showLineNumbers'.toLowerCase()) ||
-          options.showLineNumbers
+          (meta.toLowerCase().includes('showLineNumbers'.toLowerCase()) ||
+            options.showLineNumbers) &&
+          !falseShowLineNumbersStr.some((str) => meta.toLowerCase().includes(str))
         ) {
           line.properties.line = [(i + startingLineNumber).toString()]
           // @ts-ignore

--- a/test.js
+++ b/test.js
@@ -210,6 +210,44 @@ test('showLineNumbers option add line numbers', async () => {
   assert.not(result.match(/line="3"/g))
 })
 
+test('not show line number when showLineNumbers=false', async () => {
+  const meta = 'showLineNumbers=false'
+  const result = processHtml(
+    dedent`
+    <div>
+      <pre>
+      <code class="language-py code-highlight">x = 6
+      y = 7
+      </code>
+      </pre>
+    </div>
+    `,
+    { showLineNumbers: true },
+    meta
+  ).trim()
+  assert.not(result.match(/line="1"/g))
+  assert.not(result.match(/line="2"/g))
+})
+
+test('not show line number when showLineNumbers={false}', async () => {
+  const meta = 'showLineNumbers={false}'
+  const result = processHtml(
+    dedent`
+    <div>
+      <pre>
+      <code class="language-py code-highlight">x = 6
+      y = 7
+      </code>
+      </pre>
+    </div>
+    `,
+    { showLineNumbers: true },
+    meta
+  ).trim()
+  assert.not(result.match(/line="1"/g))
+  assert.not(result.match(/line="2"/g))
+})
+
 test('showLineNumbers property works in meta field', async () => {
   const meta = 'showLineNumbers'
   const result = processHtml(


### PR DESCRIPTION
Fix #38 

Not show line numbers on a per block basis for the following:
- `showLineNumbers=false`
- `showLineNumbers="false"`
- `showLineNumbers={false}`