### PR TITLE
feat: added support for diff with syntax highlight

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -197,8 +197,8 @@ const rehypePrismGenerator = (refractor) => {
       if (lang) {
         try {
           let rootLang
-          if (lang.includes('diff:')){
-            rootLang=lang.split(':')[1]
+          if (lang?.includes('diff-')){
+            rootLang=lang.split('-')[1]
           } else{
             rootLang=lang
           }
@@ -273,9 +273,9 @@ const rehypePrismGenerator = (refractor) => {
         }
 
         // Diff classes
-        if ((lang === 'diff' || lang.includes('diff:')) && toString(line).substring(0, 1) === '-') {
+        if ((lang === 'diff' || lang?.includes('diff-')) && toString(line).substring(0, 1) === '-') {
           line.properties.className.push('deleted')
-        } else if ((lang === 'diff' || lang.includes('diff:')) && toString(line).substring(0, 1) === '+') {
+        } else if ((lang === 'diff' || lang?.includes('diff-')) && toString(line).substring(0, 1) === '+') {
           line.properties.className.push('inserted')
         }
       }

--- a/src/generator.js
+++ b/src/generator.js
@@ -196,11 +196,17 @@ const rehypePrismGenerator = (refractor) => {
       // Syntax highlight
       if (lang) {
         try {
+          let rootLang
+          if (lang.includes('diff:')){
+            rootLang=lang.split(':')[1]
+          } else{
+            rootLang=lang
+          }
           // @ts-ignore
-          refractorRoot = refractor.highlight(toString(node), lang)
+          refractorRoot = refractor.highlight(toString(node), rootLang)
           // @ts-ignore className is already an array
           parent.properties.className = (parent.properties.className || []).concat(
-            'language-' + lang
+            'language-' + rootLang
           )
         } catch (err) {
           if (options.ignoreMissing && /Unknown language/.test(err.message)) {
@@ -267,9 +273,9 @@ const rehypePrismGenerator = (refractor) => {
         }
 
         // Diff classes
-        if (lang === 'diff' && toString(line).substring(0, 1) === '-') {
+        if ((lang === 'diff' || lang.includes('diff:')) && toString(line).substring(0, 1) === '-') {
           line.properties.className.push('deleted')
-        } else if (lang === 'diff' && toString(line).substring(0, 1) === '+') {
+        } else if ((lang === 'diff' || lang.includes('diff:')) && toString(line).substring(0, 1) === '+') {
           line.properties.className.push('inserted')
         }
       }

--- a/test.js
+++ b/test.js
@@ -397,4 +397,22 @@ test('works as a remarkjs / unifiedjs plugin', () => {
   assert.is(result, expected)
 })
 
+test('diff and code highlighting should work together', () => {
+  const result = processHtml(
+    dedent`
+    <pre><code class="language-diff-css">
+    .hello{
+    - background:url('./urel.png');
+    + background-image:url('./urel.png');
+    }
+    </code></pre>
+  `,
+    { ignoreMissing: true }
+  )
+  assert.ok(result.includes(`<pre class="language-css">`))
+  assert.ok(result.includes(`<span class="code-line inserted">`))
+  assert.ok(result.includes(`<span class="code-line deleted">`))
+  assert.ok(result.includes(`<span class="code-line">`))
+})
+
 test.run()


### PR DESCRIPTION
added support for syntax highlighting for diff
by using the `diff:` prefix you can get syntax highlight and diff for your code
![mdx-snippet](https://user-images.githubusercontent.com/63613078/185742653-29d0801d-a1f4-496f-aa60-1624acca0657.png)
mdx code
![mdx-result](https://user-images.githubusercontent.com/63613078/185742681-4aa87a32-0637-4ada-acbc-4e7fe864ca0c.png)
result
