### PR TITLE
feat: meta string support with astro

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -176,7 +176,7 @@ const rehypePrismGenerator = (refractor) => {
         return
       }
 
-      let meta = node.data && node.data.meta ? /** @type {string} */ (node.data.meta) : ''
+      let meta = /** @type {string} */ (node?.data?.meta || node?.properties?.metastring || '')
       // Coerce className to array
       if (node.properties.className) {
         if (typeof node.properties.className === 'boolean') {


### PR DESCRIPTION
[Astro converts `data.meta` to `properties.metastring`](https://github.com/withastro/astro/pull/5335) as the whole `data` key is removed by `rehype-raw`. [There's a related astro issue here](https://github.com/withastro/astro/issues/5163).

The change in this PR is to adjust the `meta` value to use:
1. `data.meta` if found
2. or `properties.metastring` if found
3. or an empty string