### PR TITLE
fix: support nextjs 13 (fix #65)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-import rehypePrismGenerator from './src/generator.js'
-import rehypePrismCommon from './src/common.js'
-import rehypePrism from './src/all.js'
-
-export { rehypePrismGenerator, rehypePrismCommon }
-export default rehypePrism

--- a/package.json
+++ b/package.json
@@ -6,27 +6,15 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/rehype-prism-plus.es.js",
-  "module": "./dist/rehype-prism-plus.es.js",
+  "main": "./dist/index.es.js",
+  "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/rehype-prism-plus.es.js"
-    },
-    "./common": {
-      "types": "./dist/src/common.d.ts",
-      "import": "./dist/common.es.js"
-    },
-    "./all": {
-      "types": "./dist/src/all.d.ts",
-      "import": "./dist/all.es.js"
-    },
-    "./generator": {
-      "types": "./dist/src/generator.d.ts",
-      "import": "./dist/generator.es.js"
-    }
+    ".": "./dist/rehype-prism-plus.es.js",
+    "./common": "./dist/common.es.js",
+    "./all": "./dist/all.js",
+    "./generator": "./dist/generator.es.js"
   },
   "typesVersions": {
     "*": {
@@ -34,18 +22,18 @@
         "./dist/index"
       ],
       "common": [
-        "./dist/src/common"
+        "./dist/common"
       ],
       "all": [
-        "./dist/src/all"
+        "./dist/all"
       ],
       "generator": [
-        "./dist/src/generator"
+        "./dist/generator"
       ]
     }
   },
   "scripts": {
-    "build": "tsc -b && microbundle index.js src/common.js src/all.js src/generator.js --format esm",
+    "build": "tsc -b && microbundle src/index.js src/common.js src/all.js src/generator.js --format esm",
     "tsc": "tsc --watch",
     "lint": "eslint .",
     "prettier": "prettier --write '*.js'",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,22 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
-    ".": "./dist/rehype-prism-plus.es.js",
-    "./common": "./dist/common.es.js",
-    "./all": "./dist/all.js",
-    "./generator": "./dist/generator.es.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.es.js"
+    },
+    "./common": {
+      "types": "./dist/common.d.ts",
+      "default": "./dist/common.es.js"
+    },
+    "./all": {
+      "types": "./dist/all.d.ts",
+      "default": "./dist/all.es.js"
+    },
+    "./generator": {
+      "types": "./dist/generator.d.ts",
+      "default": "./dist/generator.es.js"
+    }
   },
   "typesVersions": {
     "*": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import rehypePrismGenerator from './generator.js'
+import rehypePrismCommon from './common.js'
+import rehypePrism from './all.js'
+
+export { rehypePrismGenerator, rehypePrismCommon }
+export default rehypePrism

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import rehypeStringify from 'rehype-stringify'
 import dedent from 'dedent'
-import rehypePrism from './index.js'
+import rehypePrism from './src/index.js'
 
 /**
  * Mock meta in code block

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["index.js", "src/*"],
+  "include": ["src/*"],
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],


### PR DESCRIPTION
- https://github.com/timlrx/rehype-prism-plus/issues/65
- https://github.com/timlrx/rehype-prism-plus/pull/64#issuecomment-1667103879
- https://github.com/timlrx/rehype-prism-plus/issues/63
- https://github.com/uiwjs/react-md-editor/issues/561

https://github.com/timlrx/rehype-prism-plus/blob/d8582ab809420b463f57782e7f67dadae488207b/package.json#L13-L29

The reason for the error is: `import`+`require` must be used in combination in the exports field in next.js. @timlrx 