### PR TITLE
Feat: Add Option to Show Line Numbers for Specific Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,16 @@ Note: The language must be first registered with [refractor].
 
 #### options.showLineNumbers
 
-Type: `boolean`.
-Default: `false`.
+Type: `boolean | string[]`  
+Default: `false`
 
-By default, line numbers will only be displayed for code block cells with a meta property that includes 'showLineNumbers'. To control the starting line number use `showLineNumbers=X`, where `X` is the starting line number as a meta property for the code block.
+By default, line numbers will only be displayed for code block cells with a meta property that includes 'showLineNumbers'. To control the starting line number, use `showLineNumbers=X`, where `X` is the starting line number as a meta property for the code block.
 
-If you would like to show line numbers for all code blocks, without specifying the meta property, set this to `true`.
+If you would like to show line numbers for all code blocks without specifying the meta property, set this to `true`.
 
-**Note**: This will wrongly assign a language class and the class might appear as `language-{1,3}` or `language-showLineNumbers`, but allow the language highlighting and line number function to work. An possible approach would be to add a placeholder like `unknown` so the `div` will have `class="language-unknown"`
+Alternatively, you can specify an array of languages for which the line numbers should be shown. For example, setting the option as `showLineNumbers: ['typescript']` will display line numbers only for code blocks with the language `typescript`, while other languages (e.g., `text`) will not display line numbers.
+
+**Note**: When this option is used, the plugin may assign a language class incorrectly (e.g., `language-{1,3}`, `language-showLineNumbers`, or `language-{specifiedLanguage}`). One possible approach to mitigate this is to add a placeholder like `unknown` so that the resulting `div` will have a class such as `language-unknown`.
 
 [rehype]: https://github.com/wooorm/rehype
 [prism]: http://prismjs.com/

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you would like to show line numbers for all code blocks without specifying th
 
 Alternatively, you can specify an array of languages for which the line numbers should be shown. For example, setting the option as `showLineNumbers: ['typescript']` will display line numbers only for code blocks with the language `typescript`, while other languages (e.g., `text`) will not display line numbers.
 
-**Note**: When this option is used, the plugin may assign a language class incorrectly (e.g., `language-{1,3}`, `language-showLineNumbers`, or `language-{specifiedLanguage}`). One possible approach to mitigate this is to add a placeholder like `unknown` so that the resulting `div` will have a class such as `language-unknown`.
+**Note**: This will wrongly assign a language class and the class might appear as `language-{1,3}` or `language-showLineNumbers`, but allow the language highlighting and line number function to work. An possible approach would be to add a placeholder like `unknown` so the `div` will have `class="language-unknown"`
 
 [rehype]: https://github.com/wooorm/rehype
 [prism]: http://prismjs.com/

--- a/src/generator.js
+++ b/src/generator.js
@@ -3,7 +3,7 @@
  * @typedef {import('hast').Root} Root
  * @typedef Options options
  *   Configuration.
- * @property {boolean} [showLineNumbers]
+ * @property {boolean|string[]} [showLineNumbers]
  *   Set `showLineNumbers` to `true` to always display line number
  * @property {boolean} [ignoreMissing]
  *   Set `ignoreMissing` to `true` to ignore unsupported languages and line highlighting when no language is specified
@@ -276,11 +276,14 @@ const rehypePrismGenerator = (refractor) => {
         line.children = treeExtract.children
 
         // Line number
-        if (
+        const isShowNumbers =
           (meta.toLowerCase().includes('showLineNumbers'.toLowerCase()) ||
-            options.showLineNumbers) &&
+            options.showLineNumbers === true ||
+            (typeof options.showLineNumbers === 'object' &&
+              options.showLineNumbers.includes(lang))) &&
           !falseShowLineNumbersStr.some((str) => meta.toLowerCase().includes(str))
-        ) {
+
+        if (isShowNumbers) {
           line.properties.line = [(i + startingLineNumber).toString()]
           line.properties.className.push('line-number')
         }

--- a/test.js
+++ b/test.js
@@ -244,6 +244,40 @@ test('not show line number when showLineNumbers=false', async () => {
   assert.not(result.match(/line="2"/g))
 })
 
+test('show line numbers when showLineNumbers=string[] includes target language', async () => {
+  const result = processHtml(
+    dedent`
+    <div>
+      <pre>
+      <code class="language-typescript code-highlight">x = 6
+      y = 7
+      </code>
+      </pre>
+    </div>
+    `,
+    { showLineNumbers: ['typescript', 'py'] }
+  ).trim()
+  assert.ok(result.match(/line="1"/g))
+  assert.ok(result.match(/line="2"/g))
+})
+
+test('not show line numbers when showLineNumbers=string[] does not include target language', async () => {
+  const result = processHtml(
+    dedent`
+    <div>
+      <pre>
+      <code class="language-javascript code-highlight">x = 6
+      y = 7
+      </code>
+      </pre>
+    </div>
+    `,
+    { showLineNumbers: ['typescript', 'py'] }
+  ).trim()
+  assert.not(result.match(/line="1"/g))
+  assert.not(result.match(/line="2"/g))
+})
+
 test('not show line number when showLineNumbers={false}', async () => {
   const meta = 'showLineNumbers={false}'
   const result = processHtml(


### PR DESCRIPTION
**Issue:** #74

**Description:**  
This pull request extends the `showLineNumbers` option from a boolean to `boolean | string[]`. Currently, setting `showLineNumbers` to `true` displays line numbers for all code blocks that include the meta property 'showLineNumbers'. With this change, you can specify an array of languages (e.g., `['typescript']`) to show line numbers only for those languages. Other languages, like plain text, will not display line numbers.

**Changes:**  
- **Type Update:** Change `showLineNumbers` type from `boolean` to `boolean | string[]`.
- **Logic Modification:** Update the line numbering logic to check if `showLineNumbers` is an array. If it is, only add line numbers for code blocks whose language is included in the array.
- **Documentation:** Update docs and examples to reflect the new functionality.

**Usage Examples:**

```js
// Display line numbers for all code blocks
showLineNumbers: true

// Display line numbers only for code blocks with the 'typescript' or 'java' language
showLineNumbers: ['typescript', 'java']
